### PR TITLE
style: aligning formatting for all of the credo changed files

### DIFF
--- a/apps/vc-api/src/config/env-vars-validation-schema.ts
+++ b/apps/vc-api/src/config/env-vars-validation-schema.ts
@@ -12,5 +12,5 @@ export const envVarsValidationSchema = Joi.object({
   ASKAR_LABEL: Joi.string().default('vc-api-agent'),
   ASKAR_WALLET_ID: Joi.string().default('vc-api-wallet'),
   ASKAR_WALLET_KEY: Joi.string().default('vc-api-wallet-key-0001'),
-  ASKAR_WALLET_DB_TYPE: Joi.string().default('sqlite'),
+  ASKAR_WALLET_DB_TYPE: Joi.string().default('sqlite')
 });

--- a/apps/vc-api/src/credo/credo.module.ts
+++ b/apps/vc-api/src/credo/credo.module.ts
@@ -4,6 +4,6 @@ import { CredoService } from './credo.service';
 @Global()
 @Module({
   providers: [CredoService],
-  exports: [CredoService],
+  exports: [CredoService]
 })
 export class CredoModule {}

--- a/apps/vc-api/src/credo/credo.service.ts
+++ b/apps/vc-api/src/credo/credo.service.ts
@@ -1,19 +1,19 @@
-import { AskarModule, AskarWallet } from "@credo-ts/askar";
-import { Agent, InitConfig, SigningProviderRegistry, ConsoleLogger, WalletConfig } from "@credo-ts/core";
-import { agentDependencies } from "@credo-ts/node";
-import { ariesAskar } from "@hyperledger/aries-askar-nodejs";
+import { AskarModule, AskarWallet } from '@credo-ts/askar';
+import { Agent, InitConfig, SigningProviderRegistry, ConsoleLogger, WalletConfig } from '@credo-ts/core';
+import { agentDependencies } from '@credo-ts/node';
+import { ariesAskar } from '@hyperledger/aries-askar-nodejs';
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 
 @Injectable()
-export class CredoService implements OnModuleInit, OnModuleDestroy{
+export class CredoService implements OnModuleInit, OnModuleDestroy {
   private readonly walletConfig: WalletConfig = {
     id: process.env['ASKAR_WALLET_ID'],
     key: process.env['ASKAR_WALLET_KEY'],
     storage: {
-      type: process.env['ASKAR_WALLET_DB_TYPE'],
-    },
+      type: process.env['ASKAR_WALLET_DB_TYPE']
+    }
   };
-  private readonly askarAgent: Agent<{ askar: AskarModule; }>;
+  private readonly askarAgent: Agent<{ askar: AskarModule }>;
   private readonly askarWallet: AskarWallet;
   private initialized = false;
 
@@ -21,7 +21,7 @@ export class CredoService implements OnModuleInit, OnModuleDestroy{
     // Initialize agent and wallet synchronously
     const config: InitConfig = {
       label: process.env['ASKAR_LABEL'],
-      walletConfig: this.walletConfig,
+      walletConfig: this.walletConfig
     };
 
     // Create the agent
@@ -30,16 +30,16 @@ export class CredoService implements OnModuleInit, OnModuleDestroy{
       dependencies: agentDependencies,
       modules: {
         askar: new AskarModule({
-          ariesAskar,
-        }),
-      },
+          ariesAskar
+        })
+      }
     });
 
     // Create the wallet
     this.askarWallet = new AskarWallet(
       new ConsoleLogger(),
       new agentDependencies.FileSystem(),
-      new SigningProviderRegistry([]),
+      new SigningProviderRegistry([])
     );
   }
 
@@ -60,7 +60,7 @@ export class CredoService implements OnModuleInit, OnModuleDestroy{
   // Accessor for the agent
   public get agent(): Agent<{ askar: AskarModule }> {
     if (!this.initialized) {
-      throw new Error("Credo Agent is not initialized yet.");
+      throw new Error('Credo Agent is not initialized yet.');
     }
     return this.askarAgent;
   }
@@ -68,7 +68,7 @@ export class CredoService implements OnModuleInit, OnModuleDestroy{
   // Accessor for the wallet
   public get wallet(): AskarWallet {
     if (!this.initialized) {
-      throw new Error("Credo wallet is not initialized yet.");
+      throw new Error('Credo wallet is not initialized yet.');
     }
     return this.askarWallet;
   }

--- a/apps/vc-api/src/did/did.service.spec.ts
+++ b/apps/vc-api/src/did/did.service.spec.ts
@@ -33,8 +33,8 @@ describe('DIDService', () => {
         DIDService,
         {
           provide: CredoService,
-          useValue: mockCredoService,
-        },
+          useValue: mockCredoService
+        }
       ]
     }).compile();
 

--- a/apps/vc-api/src/key/key.service.spec.ts
+++ b/apps/vc-api/src/key/key.service.spec.ts
@@ -25,9 +25,9 @@ describe('KeyService', () => {
       imports: [TypeOrmSQLiteModule(), TypeOrmModule.forFeature([KeyPair]), CredoModule],
       providers: [
         KeyService,
-        { 
+        {
           provide: CredoService,
-          useValue: mockCredoService,
+          useValue: mockCredoService
         }
       ]
     }).compile();
@@ -42,7 +42,7 @@ describe('KeyService', () => {
   it('should return undefined if asked for privateKey that it does not have', async () => {
     jest.spyOn(mockCredoService.wallet, 'withSession').mockImplementation(async (callback) => {
       return await callback({
-        fetchKey: jest.fn().mockResolvedValue(null),
+        fetchKey: jest.fn().mockResolvedValue(null)
       });
     });
     const result = await service.getPublicKeyFromKeyId('thumbprint-of-not-available-key');
@@ -54,7 +54,7 @@ describe('KeyService', () => {
       jest.spyOn(mockCredoService.agent.wallet, 'createKey').mockResolvedValue(createdKey);
       jest.spyOn(mockCredoService.wallet, 'withSession').mockImplementation(async (callback) => {
         return await callback({
-          fetchKey: jest.fn().mockResolvedValue(keyEntryObject),
+          fetchKey: jest.fn().mockResolvedValue(keyEntryObject)
         });
       });
       const keyDescription = await service.generateKey({ type: keyType.ed25519 });

--- a/apps/vc-api/src/seeder/seeder.service.spec.ts
+++ b/apps/vc-api/src/seeder/seeder.service.spec.ts
@@ -48,9 +48,10 @@ describe('SeederService', () => {
       let exception: Error;
 
       beforeEach(async function () {
-        mockKeyService.importKey.mockReset()
-          .mockResolvedValueOnce({keyId: "EMALqbXvBBETNa6wjhJbJMAHiLZotMJYT4KnicduGjii"})
-          .mockResolvedValueOnce({keyId: "5M7AxPh4tTF7kJH3yZoi7AUZSVVF8Xi7QWybrX9vNEPx"});
+        mockKeyService.importKey
+          .mockReset()
+          .mockResolvedValueOnce({ keyId: 'EMALqbXvBBETNa6wjhJbJMAHiLZotMJYT4KnicduGjii' })
+          .mockResolvedValueOnce({ keyId: '5M7AxPh4tTF7kJH3yZoi7AUZSVVF8Xi7QWybrX9vNEPx' });
         mockDIDService.registerKeyDID.mockReset();
         try {
           await service.seed();

--- a/apps/vc-api/src/seeder/seeder.service.ts
+++ b/apps/vc-api/src/seeder/seeder.service.ts
@@ -12,10 +12,7 @@ import { KeyService } from '../key/key.service';
 export class SeederService {
   private readonly logger = new Logger(SeederService.name, { timestamp: true });
 
-  constructor(
-    private readonly keyService: KeyService,
-    private readonly didService: DIDService
-  ) {}
+  constructor(private readonly keyService: KeyService, private readonly didService: DIDService) {}
 
   async seed() {
     this.logger.debug('seeding database');

--- a/apps/vc-api/src/utils/crypto.utils.ts
+++ b/apps/vc-api/src/utils/crypto.utils.ts
@@ -1,7 +1,5 @@
-import { TypedArrayEncoder } from "@credo-ts/core"
+import { TypedArrayEncoder } from '@credo-ts/core';
 
-export const Base64ToBase58 = (base64: string) : string => {
-    return TypedArrayEncoder.toBase58(
-        TypedArrayEncoder.fromBase64(base64)
-    );    
-}
+export const Base64ToBase58 = (base64: string): string => {
+  return TypedArrayEncoder.toBase58(TypedArrayEncoder.fromBase64(base64));
+};

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
@@ -28,7 +28,11 @@ import { ProvePresentationOptionsDto } from './dtos/prove-presentation-options.d
 import { CredoService } from '../../credo/credo.service';
 import { mockCredoService } from '../../credo/__mocks__/credo.service';
 import { CredoModule } from '../../credo/credo.module';
-import { JsonTransformer, W3cJsonLdVerifiableCredential, W3cJsonLdVerifiablePresentation } from '@credo-ts/core';
+import {
+  JsonTransformer,
+  W3cJsonLdVerifiableCredential,
+  W3cJsonLdVerifiablePresentation
+} from '@credo-ts/core';
 
 describe('CredentialsService', () => {
   let service: CredentialsService;
@@ -187,11 +191,11 @@ describe('CredentialsService', () => {
   });
 
   it('should be able to generate DIDAuth', async () => {
-    jest
-      .spyOn(mockCredoService.agent.w3cCredentials, 'signPresentation')
-      .mockResolvedValue(
-        JsonTransformer.fromJSON(didAuth.signedPresentation, W3cJsonLdVerifiablePresentation, {validate: false})
-      );
+    jest.spyOn(mockCredoService.agent.w3cCredentials, 'signPresentation').mockResolvedValue(
+      JsonTransformer.fromJSON(didAuth.signedPresentation, W3cJsonLdVerifiablePresentation, {
+        validate: false
+      })
+    );
     const vp = await service.didAuthenticate(didAuth.presentation);
     expect(vp.holder).toEqual(did);
     expect(vp.proof).toBeDefined();

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.ts
@@ -56,16 +56,14 @@ export class CredentialsService implements CredentialVerifier {
     return w3cVerifiableCredential.toJson() as VerifiableCredentialDto;
   }
 
-  async verifyCredential(
-    vc: VerifiableCredentialDto
-  ): Promise<VerificationResultDto> {
+  async verifyCredential(vc: VerifiableCredentialDto): Promise<VerificationResultDto> {
     const w3cVerifyCredentialOptions: W3cVerifyCredentialOptions<ClaimFormat.LdpVc> = {
       credential: W3cJsonLdVerifiableCredential.fromJson(vc)
     };
 
     // Using "any" until Credo types are fixed https://github.com/openwallet-foundation/credo-ts/issues/2043
-    const verifyCredential: W3cVerifyCredentialResult = 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const verifyCredential: W3cVerifyCredentialResult =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await this.credoService.agent.w3cCredentials.verifyCredential(w3cVerifyCredentialOptions as any);
     return transformVerificationResult(verifyCredential);
   }

--- a/apps/vc-api/test/did/did.service.spec.data.ts
+++ b/apps/vc-api/test/did/did.service.spec.data.ts
@@ -1,73 +1,73 @@
-import { DidDocument } from "@credo-ts/core";
-import { IKeyDescription } from "@energyweb/w3c-ccg-webkms";
-import { KeyEntryObject } from "@hyperledger/aries-askar-shared";
-import { DIDDocument } from "did-resolver";
-import { KeyPairDto } from "../../src/key/dtos/key-pair.dto";
+import { DidDocument } from '@credo-ts/core';
+import { IKeyDescription } from '@energyweb/w3c-ccg-webkms';
+import { KeyEntryObject } from '@hyperledger/aries-askar-shared';
+import { DIDDocument } from 'did-resolver';
+import { KeyPairDto } from '../../src/key/dtos/key-pair.dto';
 
 export const generatedKey: IKeyDescription = {
-    keyId: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
+  keyId: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
 };
 export const didDocument: DIDDocument = {
-  "context": [
-    "https://w3id.org/did/v1",
-    "https://w3id.org/security/suites/ed25519-2018/v1",
-    "https://w3id.org/security/suites/x25519-2019/v1"
+  context: [
+    'https://w3id.org/did/v1',
+    'https://w3id.org/security/suites/ed25519-2018/v1',
+    'https://w3id.org/security/suites/x25519-2019/v1'
   ],
-  "id": "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra",
-  "verificationMethod": [
+  id: 'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra',
+  verificationMethod: [
     {
-      "id": "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra",
-      "type": "Ed25519VerificationKey2018",
-      "controller": "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra",
-      "publicKeyBase58": "6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC"
+      id: 'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra',
+      type: 'Ed25519VerificationKey2018',
+      controller: 'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra',
+      publicKeyBase58: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
     }
   ],
-  "authentication": [
-    "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra"
+  authentication: [
+    'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra'
   ],
-  "assertionMethod": [
-    "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra"
+  assertionMethod: [
+    'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra'
   ],
-  "keyAgreement": [
+  keyAgreement: [
     {
-      "id": "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6LSeq2Z3VnKx2mRpTV3b8szdfvTaBeAKBmm943gQYUuf2qe",
-      "type": "X25519KeyAgreementKey2019",
-      "controller": "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra",
-      "publicKeyBase58": "49rPXByTra3gj57H4VN3K5hyj373cabcG5Kzv5qNwf4t"
+      id: 'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6LSeq2Z3VnKx2mRpTV3b8szdfvTaBeAKBmm943gQYUuf2qe',
+      type: 'X25519KeyAgreementKey2019',
+      controller: 'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra',
+      publicKeyBase58: '49rPXByTra3gj57H4VN3K5hyj373cabcG5Kzv5qNwf4t'
     }
   ],
-  "capabilityInvocation": [
-    "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra"
+  capabilityInvocation: [
+    'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra'
   ],
-  "capabilityDelegation": [
-    "did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra"
+  capabilityDelegation: [
+    'did:key:z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra#z6MkkHpdGLCEmsp6cPACigf2EU7GfsXqpwY5Dwn63SXYw6Ra'
   ]
 } as DidDocument;
 
 export const keyEntryObject: KeyEntryObject = {
   key: {
-      get jwkPublic() {
-          return {
-              "kty": "OKP",
-              "crv": "Ed25519",
-              "x": "VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU",
-              "kid": "6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC"
-          }
-      }
-  } as any,
+    get jwkPublic() {
+      return {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: 'VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU',
+        kid: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
+      };
+    }
+  } as any
 } as any;
 
 export const keyPair: KeyPairDto = {
-  "publicKey": {
-    "kty": "OKP",
-    "crv": "Ed25519",
-    "x": "VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU",
-    "kid": "6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC"
+  publicKey: {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: 'VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU',
+    kid: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
   },
-  "privateKey": {
-    "kty": "OKP",
-    "crv": "Ed25519",
-    "x": "VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU",
-    "d": "IGPeDFjy0q9WFK13SQlPDTMWpbc5TI0lgMqq03nJchw"
+  privateKey: {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: 'VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU',
+    d: 'IGPeDFjy0q9WFK13SQlPDTMWpbc5TI0lgMqq03nJchw'
   }
 };

--- a/apps/vc-api/test/key/key.service.spec.data.ts
+++ b/apps/vc-api/test/key/key.service.spec.data.ts
@@ -1,20 +1,20 @@
-import { KeyEntryObject } from "@hyperledger/aries-askar-shared"
-import { Key } from "@credo-ts/core";
+import { KeyEntryObject } from '@hyperledger/aries-askar-shared';
+import { Key } from '@credo-ts/core';
 
 export const createdKey: Key = {
-    "keyType":"ed25519",
-    "publicKeyBase58":"6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC"
+  keyType: 'ed25519',
+  publicKeyBase58: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
 } as any;
 
 export const keyEntryObject: KeyEntryObject = {
-    key: {
-        get jwkPublic() {
-            return {
-                "kty": "OKP",
-                "crv": "Ed25519",
-                "x": "VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU",
-                "kid": "6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC"
-            }
-        }
-    } as any,
-  } as any;
+  key: {
+    get jwkPublic() {
+      return {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: 'VrsnBw1-JP3R4xuaQqDQI9pXM2YP1Per79Unm2UkCaU',
+        kid: '6qZag5woSLKdVtKW37hBPNZGrJFzR4HiXvsADAZY1seC'
+      };
+    }
+  } as any
+} as any;

--- a/apps/vc-api/test/vc-api/credential.service.spec.data.ts
+++ b/apps/vc-api/test/vc-api/credential.service.spec.data.ts
@@ -346,21 +346,19 @@ export const didAuth = {
   presentation: {
     did: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
     options: {
-      verificationMethod: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF#z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
+      verificationMethod:
+        'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF#z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
       proofPurpose: 'authentication',
-      challenge: 'some-challenge',
+      challenge: 'some-challenge'
     }
   } as AuthenticateDto,
   signedPresentation: {
-    '@context': [
-      'https://www.w3.org/2018/credentials/v1'
-    ],
-    type: [
-      'VerifiablePresentation'
-    ],
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiablePresentation'],
     holder: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
     proof: {
-      verificationMethod: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF#z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
+      verificationMethod:
+        'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF#z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
       type: 'Ed25519Signature2018',
       created: '2024-09-18T17:55:18Z',
       proofPurpose: 'authentication',

--- a/apps/vc-api/test/vc-api/credential.service.spec.key.ts
+++ b/apps/vc-api/test/vc-api/credential.service.spec.key.ts
@@ -11,7 +11,7 @@ export const key = {
   kid: 'zWME913jdYrILuYD-ot-jDbmzqz34HqlCUZ6CMdJnyo'
 };
 
-export const did = "did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF";
+export const did = 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF';
 export const didDoc = {
   id: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
   verificationMethod: [


### PR DESCRIPTION
I noticed that the format was inconsistent in several of the files changed for Credo integration, relative to the configured prettier style and the way that several of the other files are formatted.

There should be a pre-commit hook that auto formats all of the files, but perhaps it is not running somehow 🤔 