### PR TITLE
fix(credo.service): use config service

### DIFF
--- a/apps/vc-api/src/config/env-vars-validation-schema.ts
+++ b/apps/vc-api/src/config/env-vars-validation-schema.ts
@@ -9,8 +9,8 @@ export const envVarsValidationSchema = Joi.object({
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   PORT: Joi.number().integer().positive().default(3000),
   BASE_URL: Joi.string().uri().default('http://localhost:3000'),
-  ASKAR_LABEL: Joi.string().default('vc-api-agent'),
-  ASKAR_WALLET_ID: Joi.string().default('vc-api-wallet'),
-  ASKAR_WALLET_KEY: Joi.string().default('vc-api-wallet-key-0001'),
-  ASKAR_WALLET_DB_TYPE: Joi.string().default('sqlite')
+  CREDO_LABEL: Joi.string().default('vc-api-agent'),
+  CREDO_WALLET_ID: Joi.string().default('vc-api-wallet'),
+  CREDO_WALLET_KEY: Joi.string().default('vc-api-wallet-key-0001'),
+  CREDO_WALLET_DB_TYPE: Joi.string().default('sqlite')
 });

--- a/apps/vc-api/src/credo/credo.module.ts
+++ b/apps/vc-api/src/credo/credo.module.ts
@@ -1,8 +1,10 @@
 import { Module, Global } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { CredoService } from './credo.service';
 
 @Global()
 @Module({
+  imports: [ConfigModule],
   providers: [CredoService],
   exports: [CredoService]
 })

--- a/apps/vc-api/src/credo/credo.service.ts
+++ b/apps/vc-api/src/credo/credo.service.ts
@@ -3,24 +3,27 @@ import { Agent, InitConfig, SigningProviderRegistry, ConsoleLogger, WalletConfig
 import { agentDependencies } from '@credo-ts/node';
 import { ariesAskar } from '@hyperledger/aries-askar-nodejs';
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class CredoService implements OnModuleInit, OnModuleDestroy {
-  private readonly walletConfig: WalletConfig = {
-    id: process.env['ASKAR_WALLET_ID'],
-    key: process.env['ASKAR_WALLET_KEY'],
-    storage: {
-      type: process.env['ASKAR_WALLET_DB_TYPE']
-    }
-  };
+  private readonly walletConfig: WalletConfig;
   private readonly askarAgent: Agent<{ askar: AskarModule }>;
   private readonly askarWallet: AskarWallet;
   private initialized = false;
 
-  constructor() {
+  constructor(private configService: ConfigService) {
+    this.walletConfig = {
+      id: this.configService.get<string>('ASKAR_WALLET_ID'),
+      key: this.configService.get<string>('ASKAR_WALLET_KEY'),
+      storage: {
+        type: this.configService.get<string>('ASKAR_WALLET_DB_TYPE')
+      }
+    };
+
     // Initialize agent and wallet synchronously
     const config: InitConfig = {
-      label: process.env['ASKAR_LABEL'],
+      label: this.configService.get<string>('ASKAR_LABEL'),
       walletConfig: this.walletConfig
     };
 

--- a/apps/vc-api/src/credo/credo.service.ts
+++ b/apps/vc-api/src/credo/credo.service.ts
@@ -14,16 +14,16 @@ export class CredoService implements OnModuleInit, OnModuleDestroy {
 
   constructor(private configService: ConfigService) {
     this.walletConfig = {
-      id: this.configService.get<string>('ASKAR_WALLET_ID'),
-      key: this.configService.get<string>('ASKAR_WALLET_KEY'),
+      id: this.configService.get<string>('CREDO_WALLET_ID'),
+      key: this.configService.get<string>('CREDO_WALLET_KEY'),
       storage: {
-        type: this.configService.get<string>('ASKAR_WALLET_DB_TYPE')
+        type: this.configService.get<string>('CREDO_WALLET_DB_TYPE')
       }
     };
 
     // Initialize agent and wallet synchronously
     const config: InitConfig = {
-      label: this.configService.get<string>('ASKAR_LABEL'),
+      label: this.configService.get<string>('CREDO_LABEL'),
       walletConfig: this.walletConfig
     };
 


### PR DESCRIPTION
This PR:
1. Used config service. This gives more flexible on where the config values are loaded from https://docs.nestjs.com/techniques/configuration.
2. Renames vars to `CREDO` as they are for Credo abstractions/classes, not directly for Askar