### PR TITLE
fix(dockerfile): supporting credo build

### DIFF
--- a/apps/vc-api/Dockerfile
+++ b/apps/vc-api/Dockerfile
@@ -1,10 +1,8 @@
-FROM node:18.19-alpine as base
+FROM node:18.19 as base
 
 WORKDIR /app
 
 FROM base as builder
-
-RUN apk add g++ make py3-pip
 
 COPY common common
 COPY rush.json .


### PR DESCRIPTION
Changed from node-alpine to base node.
node-alpine was missing shared library ld-linux-x86-64.so.2. This lib is required by Askar.

Also removed unneeded package installs.