### PR TITLE
fix(WfExchangeEntity): rename to differentiate from ExchangeEntity

### DIFF
--- a/apps/vc-api/src/vc-api/vc-api.module.ts
+++ b/apps/vc-api/src/vc-api/vc-api.module.ts
@@ -21,7 +21,7 @@ import { VpSubmissionVerifierService } from './exchanges/vp-submission-verifier.
 import { VpSubmissionVerifierService as WfVpSubmissionVerifierService } from './workflows/vp-submission-verifier.service';
 import { WorkflowService } from './workflows/workflow.service';
 import { WorkflowEntity } from './workflows/entities/workflow.entity';
-import { ExchangeStep } from './workflows/types/exchange-step';
+import { WfExchangeEntity } from './workflows/entities/wf-exchange.entity';
 
 @Module({
   imports: [
@@ -34,13 +34,19 @@ import { ExchangeStep } from './workflows/types/exchange-step';
       PresentationReviewEntity,
       PresentationSubmissionEntity,
       WorkflowEntity,
-      ExchangeStep
+      WfExchangeEntity
     ]),
     ConfigModule,
     HttpModule
   ],
   controllers: [VcApiController],
-  providers: [CredentialsService, ExchangeService, VpSubmissionVerifierService, WorkflowService, WfVpSubmissionVerifierService],
+  providers: [
+    CredentialsService,
+    ExchangeService,
+    VpSubmissionVerifierService,
+    WorkflowService,
+    WfVpSubmissionVerifierService
+  ],
   exports: [CredentialsService, ExchangeService, WorkflowService]
 })
 export class VcApiModule {}

--- a/apps/vc-api/src/vc-api/workflows/entities/wf-exchange.entity.ts
+++ b/apps/vc-api/src/vc-api/workflows/entities/wf-exchange.entity.ts
@@ -19,8 +19,8 @@ import { ExchangeVerificationResultDto } from '../dtos/exchange-verification-res
 /**
  * NEW exchange entity (for workflows)
  */
-@Entity('workflow_exchanges')
-export class ExchangeEntity {
+@Entity()
+export class WfExchangeEntity {
   constructor(workflowId: string, initialStepDefinition: WorkflowStepDefinitionDto, initialStepId: string) {
     this.exchangeId = uuidv4();
     this.workflowId = workflowId;
@@ -49,7 +49,12 @@ export class ExchangeEntity {
     verifier: SubmissionVerifier,
     nextStep: WorkflowStepDefinitionDto,
     nextStepId: string
-  ): Promise<{ response: ExchangeResponseDto; errors: string[]; callback: CallbackConfiguration[], verificationResult: ExchangeVerificationResultDto }> {
+  ): Promise<{
+    response: ExchangeResponseDto;
+    errors: string[];
+    callback: CallbackConfiguration[];
+    verificationResult: ExchangeVerificationResultDto;
+  }> {
     // Get current step
     const currentStep = this.getCurrentStep();
     // Pass presentation to current step to process
@@ -128,7 +133,7 @@ export class ExchangeEntity {
   }
 
   public getStep(stepId: string): QueryExchangeStep | IssuanceExchangeStep {
-    const step = this.steps.find(step => step.stepId === stepId);
-    return step ;
+    const step = this.steps.find((step) => step.stepId === stepId);
+    return step;
   }
 }


### PR DESCRIPTION
Fix to this issue:
```
[Nest] 2982  - 11/21/2024, 8:41:10 PM   ERROR [ExceptionsHandler] SQLITE_CONSTRAINT: NOT NULL constraint failed: exchange_entity.interactServiceDefinitions
QueryFailedError: SQLITE_CONSTRAINT: NOT NULL constraint failed: exchange_entity.interactServiceDefinitions
    at Statement.handler (/Users/john/code/openwallet-foundation-labs/vc-api/common/temp/node_modules/.pnpm/typeorm@0.3.20_sqlite3@5.1.7_ts-node@10.9.2/src/driver/sqlite/SqliteQueryRunner.ts:135:29)
[Nest] 2982  - 11/21/2024, 8:41:10 PM   ERROR [HttpLoggerMiddleware] 500 Internal Server Error | ::ffff:127.0.0.1 | [POST] /v1/vc-api/workflows/permanent-resident-card-issuance/exchanges/ - 28ms
 FAIL  test/app.e2e-spec.ts (32.68 s)
 ```
 Also includes styling fixes.