### PR TITLE
Participate in exchange controller endpoint

### DIFF
--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -734,7 +734,7 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": { "schema": { "$ref": "#/components/schemas/VerifiablePresentationDto" } }
+            "application/json": { "schema": { "$ref": "#/components/schemas/ParticipateInExchangeDto" } }
           }
         },
         "responses": {
@@ -1423,6 +1423,19 @@
           "state": { "type": "string", "description": "Status of current exchange step" }
         },
         "required": ["exchangeId", "step", "state"]
+      },
+      "ParticipateInExchangeDto": {
+        "type": "object",
+        "properties": {
+          "verifiablePresentationRequest": {
+            "description": "Verifiable Presentation Request.\nShould conform to VP Request specification.",
+            "allOf": [{ "$ref": "#/components/schemas/VpRequestDto" }]
+          },
+          "verifiablePresentation": {
+            "description": "A JSON-LD Verifiable Presentation with a proof.",
+            "allOf": [{ "$ref": "#/components/schemas/VerifiablePresentationDto" }]
+          }
+        }
       },
       "ExchangeStateDto": {
         "type": "object",

--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -723,6 +723,44 @@
       }
     },
     "/v1/vc-api/workflows/{localWorkflowId}/exchanges/{localExchangeId}": {
+      "post": {
+        "operationId": "VcApiController_participateInWorkflowExchange",
+        "summary": "",
+        "description": "Participate in an exchange.\nPosting an empty body will start the exchange or return what the exchange is expecting to complete the next step.\nSee https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange",
+        "parameters": [
+          { "name": "localWorkflowId", "required": true, "in": "path", "schema": { "type": "string" } },
+          { "name": "localExchangeId", "required": true, "in": "path", "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/VerifiablePresentationDto" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Exchange Progressed",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ExchangeResponseDto" } }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/BadRequestErrorResponseDto" } }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/InternalServerErrorResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["vc-api"]
+      },
       "get": {
         "operationId": "VcApiController_getExchangeState",
         "summary": "",
@@ -1289,20 +1327,20 @@
       "ExchangeResponseDto": {
         "type": "object",
         "properties": {
-          "vpRequest": {
+          "verifiablePresentationRequest": {
             "description": "Verifiable Presentation Request.\nShould conform to VP-Request specification.\nWill be returned if a VP is required to obtain more information from requester\nMay not be returned if no further information is required (for example, at the end of the workflow)",
             "allOf": [{ "$ref": "#/components/schemas/VpRequestDto" }]
           },
-          "vp": {
+          "verifiablePresentation": {
             "description": "If it is an issuance response, then a vp may be provided",
             "allOf": [{ "$ref": "#/components/schemas/VerifiablePresentationDto" }]
           },
-          "processingInProgress": {
-            "type": "boolean",
-            "description": "True if an exchange submission is currently being processed or reviewed asyncronously"
+          "redirectUrl": {
+            "type": "string",
+            "description": "The URL the exchange wishes to redirect the client to."
           }
         },
-        "required": ["processingInProgress"]
+        "required": ["redirectUrl"]
       },
       "PresentationSubmissionSecureDto": { "type": "object", "properties": {} },
       "TransactionDto": {

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -56,6 +56,7 @@ import { WorkflowService } from './workflows/workflow.service';
 import { CreateWorkflowSuccessDto } from './workflows/dtos/create-workflow-success.dto';
 import { CreateExchangeSuccessDto } from './workflows/dtos/create-exchange-success.dto';
 import { ExchangeStateDto } from './workflows/dtos/exchange-state.dto';
+import { ExchangeResponseDto as WfExchangeResponseDto } from './workflows/dtos/exchange-response.dto';
 
 /**
  * VcApi API conforms to W3C vc-api
@@ -375,7 +376,7 @@ export class VcApiController {
 
   /**
    * Create a workflow
-   * 
+   *
    * @param createWorkflowRequestDto
    * @returns
    */
@@ -388,13 +389,15 @@ export class VcApiController {
   @ApiBody({ type: CreateWorkflowRequestDto })
   @ApiCreatedResponse({ type: CreateWorkflowSuccessDto })
   @ApiConflictResponse({ type: ConflictErrorResponseDto })
-  async createWorkflow(@Body() createWorkflowRequestDto: CreateWorkflowRequestDto): Promise<CreateWorkflowSuccessDto> {
+  async createWorkflow(
+    @Body() createWorkflowRequestDto: CreateWorkflowRequestDto
+  ): Promise<CreateWorkflowSuccessDto> {
     return this.workflowService.createWorkflow(createWorkflowRequestDto);
   }
 
   /**
    * Get workflow config object
-   * 
+   *
    * @param createWorkflowRequestDto
    * @returns
    */
@@ -404,17 +407,15 @@ export class VcApiController {
       'Gets the configuration of an existing workflow and returns it in the response body.\n' +
       'See https://w3c-ccg.github.io/vc-api/#get-workflow-configuration'
   })
-  @ApiOkResponse({  type: CreateWorkflowSuccessDto })
+  @ApiOkResponse({ type: CreateWorkflowSuccessDto })
   @ApiConflictResponse({ type: NotFoundException })
-  async getWorkflow(
-    @Param('localWorkflowId') localWorkflowId: string
-  ): Promise<CreateWorkflowSuccessDto> {
+  async getWorkflow(@Param('localWorkflowId') localWorkflowId: string): Promise<CreateWorkflowSuccessDto> {
     return this.workflowService.getWorkflow(localWorkflowId);
   }
 
   /**
    * Create a new exchange from an existing workflow
-   * 
+   *
    * @param createWorkflowRequestDto
    * @returns
    */
@@ -434,8 +435,38 @@ export class VcApiController {
   }
 
   /**
+   * Participate in a workflow exchange
+   *
+   * @param createWorkflowRequestDto
+   * @returns
+   */
+  @Post('/workflows/:localWorkflowId/exchanges/:localExchangeId')
+  @ApiOperation({
+    description:
+      'Participate in an exchange.\n' +
+      'Posting an empty body will start the exchange or return what the exchange is expecting to complete the next step.\n' +
+      'See https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange'
+  })
+  // @ApiBody({ type: VerifiablePresentationDto , required: false})
+  @ApiOkResponse({
+    description: 'Exchange Progressed',
+    type: WfExchangeResponseDto
+  })
+  async participateInWorkflowExchange(
+    @Param('localWorkflowId') localWorkflowId: string,
+    @Param('localExchangeId') localExchangeId: string,
+    @Body() verifiablePresentation?: VerifiablePresentationDto
+  ): Promise<WfExchangeResponseDto> {
+    return this.workflowService.participateInExchange(
+      localWorkflowId,
+      localExchangeId,
+      verifiablePresentation
+    );
+  }
+
+  /**
    * Get exchange state of a workflow
-   * 
+   *
    * @param createWorkflowRequestDto
    * @returns
    */
@@ -445,7 +476,7 @@ export class VcApiController {
       'Gets the state of an existing exchange and returns it in the response body..\n' +
       'See https://w3c-ccg.github.io/vc-api/#get-exchange-state'
   })
-  @ApiOkResponse({  type: ExchangeStateDto })
+  @ApiOkResponse({ type: ExchangeStateDto })
   @ApiConflictResponse({ type: NotFoundException })
   async getExchangeState(
     @Param('localWorkflowId') localWorkflowId: string,

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -57,6 +57,7 @@ import { CreateWorkflowSuccessDto } from './workflows/dtos/create-workflow-succe
 import { CreateExchangeSuccessDto } from './workflows/dtos/create-exchange-success.dto';
 import { ExchangeStateDto } from './workflows/dtos/exchange-state.dto';
 import { ExchangeResponseDto as WfExchangeResponseDto } from './workflows/dtos/exchange-response.dto';
+import { ParticipateInExchangeDto } from './workflows/dtos/participate-in-exchange.dto';
 
 /**
  * VcApi API conforms to W3C vc-api
@@ -436,9 +437,6 @@ export class VcApiController {
 
   /**
    * Participate in a workflow exchange
-   *
-   * @param createWorkflowRequestDto
-   * @returns
    */
   @Post('/workflows/:localWorkflowId/exchanges/:localExchangeId')
   @ApiOperation({
@@ -447,7 +445,7 @@ export class VcApiController {
       'Posting an empty body will start the exchange or return what the exchange is expecting to complete the next step.\n' +
       'See https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange'
   })
-  // @ApiBody({ type: VerifiablePresentationDto , required: false})
+  @ApiBody({ type: ParticipateInExchangeDto })
   @ApiOkResponse({
     description: 'Exchange Progressed',
     type: WfExchangeResponseDto
@@ -455,12 +453,12 @@ export class VcApiController {
   async participateInWorkflowExchange(
     @Param('localWorkflowId') localWorkflowId: string,
     @Param('localExchangeId') localExchangeId: string,
-    @Body() verifiablePresentation?: VerifiablePresentationDto
+    @Body() participateBody: ParticipateInExchangeDto
   ): Promise<WfExchangeResponseDto> {
     return this.workflowService.participateInExchange(
       localWorkflowId,
       localExchangeId,
-      verifiablePresentation
+      participateBody.verifiablePresentation
     );
   }
 

--- a/apps/vc-api/src/vc-api/workflows/dtos/participate-in-exchange.dto.ts
+++ b/apps/vc-api/src/vc-api/workflows/dtos/participate-in-exchange.dto.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 - 2023 Energy Web Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IsBoolean, IsOptional, ValidateNested } from 'class-validator';
+import { VerifiablePresentationDto } from '../../credentials/dtos/verifiable-presentation.dto';
+import { VpRequestDto } from './vp-request.dto';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Describes the possible body of a request to participate an exchange.
+ */
+export class ParticipateInExchangeDto {
+  @ValidateNested()
+  @Type(() => VpRequestDto)
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'Verifiable Presentation Request.\n' + 'Should conform to VP Request specification.'
+  })
+  verifiablePresentationRequest?: VpRequestDto;
+
+  @ValidateNested()
+  @Type(() => VerifiablePresentationDto)
+  @IsOptional()
+  @ApiPropertyOptional({ description: 'A JSON-LD Verifiable Presentation with a proof.' })
+  verifiablePresentation?: VerifiablePresentationDto;
+}

--- a/apps/vc-api/src/vc-api/workflows/workflow.service.ts
+++ b/apps/vc-api/src/vc-api/workflows/workflow.service.ts
@@ -72,7 +72,7 @@ export class WorkflowService {
     const removeTrailingSlash = (str) => (str.endsWith('/') ? str.slice(0, -1) : str);
     const exchangeId = `${removeTrailingSlash(
       baseUrl
-    )}/workflows/${localWorkflowId}/exchanges/${localExchangeId}`;
+    )}/v1/vc-api/workflows/${localWorkflowId}/exchanges/${localExchangeId}`;
     return {
       exchangeId: exchangeId,
       step: workflow.initialStep,

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -167,7 +167,7 @@ export class WalletClient {
     exchangeEndpoint: string,
     expectedQueryType: VpRequestQueryType
   ): Promise<VpRequestDto> {
-    const startWorkflowResponse = await request(this.#app.getHttpServer()).post(exchangeEndpoint).expect(201);
+    const startWorkflowResponse = await request(this.#app.getHttpServer()).post(exchangeEndpoint).expect(200);
     const vpRequest = (startWorkflowResponse.body as ExchangeResponseDto).vpRequest;
     expect(vpRequest).toBeDefined();
     const challenge = vpRequest.challenge;


### PR DESCRIPTION
Adds Participate In WF Exchange controller method. https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange
Adjusted body to be DTO that matches the spec. Note that participate service/entity methods needs to be adjusted to accept an empty body as this is what the client sends initially.