### PR TITLE
feat(wf-exchange-entity): return next action on empty participate body

### DIFF
--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -799,6 +799,47 @@
         },
         "tags": ["vc-api"]
       }
+    },
+    "/v1/vc-api/workflows/{localWorkflowId}/exchanges/{localExchangeId}/step/{localStepId}": {
+      "get": {
+        "operationId": "VcApiController_getExchangeStep",
+        "summary": "",
+        "description": "Gets the state of an existing exchange and returns it in the response body..\nSee https://w3c-ccg.github.io/vc-api/#get-exchange-state",
+        "parameters": [
+          { "name": "localWorkflowId", "required": true, "in": "path", "schema": { "type": "string" } },
+          { "name": "localExchangeId", "required": true, "in": "path", "schema": { "type": "string" } },
+          { "name": "localStepId", "required": true, "in": "path", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ExchangeStepStateDto" } }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/BadRequestErrorResponseDto" } }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/NotFoundException" } }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/InternalServerErrorResponseDto" }
+              }
+            }
+          }
+        },
+        "tags": ["vc-api"]
+      }
     }
   },
   "info": { "title": "VC-API", "description": "Sample VC-API", "version": "0.1", "contact": {} },
@@ -1441,9 +1482,23 @@
         "type": "object",
         "properties": {
           "exchangeId": { "type": "string", "description": "Exchange Id" },
+          "step": { "type": "string", "description": "Current step in the exchange" },
           "state": { "type": "string", "description": "Exchange status" }
         },
-        "required": ["exchangeId", "state"]
+        "required": ["exchangeId", "step", "state"]
+      },
+      "ExchangeStepStateDto": {
+        "type": "object",
+        "properties": {
+          "exchangeId": { "type": "string", "description": "Exchange Id" },
+          "stepId": { "type": "string", "description": "Step Id" },
+          "step": { "type": "object", "description": "Exchange step information" },
+          "stepResponse": {
+            "description": "Exchange step information",
+            "allOf": [{ "$ref": "#/components/schemas/ExchangeResponseDto" }]
+          }
+        },
+        "required": ["exchangeId", "stepId", "step", "stepResponse"]
       }
     }
   }

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -9,6 +9,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  HttpStatus,
   Logger,
   NotFoundException,
   Param,
@@ -399,7 +400,7 @@ export class VcApiController {
 
   /**
    * Get workflow config object
-   * 
+   *
    * @param localWorkflowId
    * @returns
    */
@@ -417,7 +418,7 @@ export class VcApiController {
 
   /**
    * Create a new exchange from an existing workflow
-   * 
+   *
    * @param localWorkflowId
    * @returns
    */
@@ -451,6 +452,7 @@ export class VcApiController {
     description: 'Exchange Progressed',
     type: WfExchangeResponseDto
   })
+  @HttpCode(HttpStatus.OK)
   async participateInWorkflowExchange(
     @Param('localWorkflowId') localWorkflowId: string,
     @Param('localExchangeId') localExchangeId: string,
@@ -465,7 +467,7 @@ export class VcApiController {
 
   /**
    * Get exchange state of a workflow
-   * 
+   *
    * @param localWorkflowId
    * @param localExchangeId
    * @returns
@@ -487,11 +489,11 @@ export class VcApiController {
 
   /**
    * Get exchange step state of a workflow
-   * 
+   *
    * @param localWorkflowId
    * @param localExchangeId
    * @param localStepId
-   * @returns 
+   * @returns
    */
   @Get('/workflows/:localWorkflowId/exchanges/:localExchangeId/step/:localStepId')
   @ApiOperation({
@@ -499,12 +501,12 @@ export class VcApiController {
       'Gets the state of an existing exchange and returns it in the response body..\n' +
       'See https://w3c-ccg.github.io/vc-api/#get-exchange-state'
   })
-  @ApiOkResponse({  type: ExchangeStepStateDto })
+  @ApiOkResponse({ type: ExchangeStepStateDto })
   @ApiConflictResponse({ type: NotFoundException })
   async getExchangeStep(
     @Param('localWorkflowId') localWorkflowId: string,
     @Param('localExchangeId') localExchangeId: string,
-    @Param('localStepId') localStepId:string
+    @Param('localStepId') localStepId: string
   ): Promise<ExchangeStepStateDto> {
     return this.workflowService.getExchangeStep(localWorkflowId, localExchangeId, localStepId);
   }

--- a/apps/vc-api/src/vc-api/workflows/entities/wf-exchange.entity.ts
+++ b/apps/vc-api/src/vc-api/workflows/entities/wf-exchange.entity.ts
@@ -15,6 +15,7 @@ import { IssuanceExchangeStep } from '../types/issuance-exchange-step';
 import { ExchangeResponseDto } from '../dtos/exchange-response.dto';
 import { CallbackConfiguration } from '../types/callback-configuration';
 import { ExchangeVerificationResultDto } from '../dtos/exchange-verification-result.dto';
+import { plainToInstance } from 'class-transformer';
 
 /**
  * NEW exchange entity (for workflows)
@@ -92,14 +93,28 @@ export class WfExchangeEntity {
    *
    */
   public getExchangeResponse(): ExchangeResponseDto {
-    // Get current step
     const currentStep = this.getCurrentStep();
-    // Return step status
     return currentStep.getStepResponse();
   }
 
   public getCurrentStep() {
-    return this.steps[-1];
+    return this.steps.at(-1);
+  }
+
+  public getCurrentStepRequirements(): ExchangeResponseDto {
+    const currentStep = this.getCurrentStep();
+    const vpRequestProperty: keyof QueryExchangeStep = 'vpRequest';
+    if (vpRequestProperty in currentStep) {
+      const response: { [K in keyof ExchangeResponseDto]: ExchangeResponseDto[K] } = {
+        verifiablePresentationRequest: currentStep.vpRequest
+      };
+      return plainToInstance(ExchangeResponseDto, response);
+    } else {
+      const response: { [K in keyof ExchangeResponseDto]: ExchangeResponseDto[K] } = {
+        redirectUrl: currentStep.holderRedirectUrl
+      };
+      return plainToInstance(ExchangeResponseDto, response);
+    }
   }
 
   /**

--- a/apps/vc-api/src/vc-api/workflows/workflow.service.ts
+++ b/apps/vc-api/src/vc-api/workflows/workflow.service.ts
@@ -92,14 +92,14 @@ export class WorkflowService {
     return {
       exchangeId: localExchangeId,
       step: exchange.steps[-1].stepId,
-      state: exchange.state,
+      state: exchange.state
     };
   }
 
   public async participateInExchange(
     localWorkflowId: string,
     localExchangeId: string,
-    presentation: VerifiablePresentationDto
+    presentation?: VerifiablePresentationDto
   ): Promise<ExchangeResponseDto> {
     const exchange = await this.exchangeRepository.findOneBy({
       workflowId: localWorkflowId,
@@ -107,6 +107,11 @@ export class WorkflowService {
     });
     if (exchange == null) {
       throw new NotFoundException(`exchangeId='${localExchangeId}' does not exist`);
+    }
+    // From: https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange
+    // "Posting an empty body will start the exchange or return what the exchange is expecting to complete the next step."
+    if (presentation === undefined) {
+      return exchange.getCurrentStepRequirements();
     }
 
     const workflow = await this.workflowRepository.findOneBy({ workflowId: localWorkflowId });
@@ -174,7 +179,7 @@ export class WorkflowService {
       exchangeId: localExchangeId,
       stepId: localStepId,
       step: stepInfo,
-      stepResponse: response,
+      stepResponse: response
     };
   }
 }

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -12,6 +12,7 @@ import { ProvePresentationDto } from '../src/vc-api/credentials/dtos/prove-prese
 import { VerifiablePresentationDto } from '../src/vc-api/credentials/dtos/verifiable-presentation.dto';
 import { VpRequestDto } from '../src/vc-api/exchanges/dtos/vp-request.dto';
 import { ExchangeResponseDto } from '../src/vc-api/exchanges/dtos/exchange-response.dto';
+import { ExchangeResponseDto as WfExchangeResponseDto } from '../src/vc-api/workflows/dtos/exchange-response.dto';
 import { VpRequestQueryType } from '../src/vc-api/exchanges/types/vp-request-query-type';
 import { TransactionDto } from '../src/vc-api/exchanges/dtos/transaction.dto';
 import { SubmissionReviewDto } from '../src/vc-api/exchanges/dtos/submission-review.dto';
@@ -168,7 +169,7 @@ export class WalletClient {
     expectedQueryType: VpRequestQueryType
   ): Promise<VpRequestDto> {
     const startWorkflowResponse = await request(this.#app.getHttpServer()).post(exchangeEndpoint).expect(200);
-    const vpRequest = (startWorkflowResponse.body as ExchangeResponseDto).vpRequest;
+    const vpRequest = (startWorkflowResponse.body as WfExchangeResponseDto).verifiablePresentationRequest;
     expect(vpRequest).toBeDefined();
     const challenge = vpRequest.challenge;
     expect(challenge).toBeDefined();


### PR DESCRIPTION
From https://w3c-ccg.github.io/vc-api/#participate-in-an-exchange
> Posting an empty body will start the exchange or return what the exchange is expecting to complete the next step.